### PR TITLE
Adding login form with non persistent data

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,3 +1,2 @@
 BASE_URL=http://localhost:3000
 BASE_URL_API=http://localhost:1337
-TOKEN_HOSTEL_MANAGER=""

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# am-i-in-my-municipality
+# Albergues Manager Demo
 
-> Website to know if on quarantine; Am I in my Municipality?
+> Demo
 
 ## Build Setup
 

--- a/middleware/axios.js
+++ b/middleware/axios.js
@@ -9,5 +9,4 @@
 
 export default function({ $axios }) {
   $axios.setBaseURL(process.env.BASE_URL_API)
-  $axios.setToken(process.env.TOKEN_HOSTEL_MANAGER, 'Bearer')
 }

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "albergues",
+  "name": "albergues-manager",
   "version": "1.0.0",
   "description": "Control de albergues",
-  "author": "",
+  "author": "El Salvador Conectado",
   "private": true,
   "scripts": {
     "dev": "nuxt",

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -9,18 +9,36 @@
         Albergues Manager
       </h2>
       <div class="links">
-        <nuxt-link to="/personas">Personas</nuxt-link>
+        <nuxt-link v-if="!token" to="/login" class="button-link">
+          Login
+        </nuxt-link>
+        <nuxt-link v-if="token" to="/personas" class="button-link">
+          Personas
+        </nuxt-link>
       </div>
     </div>
   </div>
 </template>
 
 <script>
+import _ from 'lodash'
 import Logo from '~/components/Logo.vue'
 
 export default {
   components: {
     Logo
+  },
+  data() {
+    return {
+      token: null
+    }
+  },
+  mounted() {
+    this.token = _.get(
+      this.$axios,
+      'defaults.headers.common.Authorization',
+      null
+    )
   }
 }
 </script>
@@ -33,6 +51,10 @@ export default {
 */
 .container {
   @apply min-h-screen flex justify-center items-center text-center mx-auto;
+}
+
+.button-link {
+  @apply border p-4 bg-blue-500;
 }
 
 .title {

--- a/pages/login/index.vue
+++ b/pages/login/index.vue
@@ -1,0 +1,58 @@
+<template>
+  <div class="page container login">
+    <form class="login__form">
+      <div>
+        <label for="">Usuario</label>
+        <input v-model="username" type="text" class="input-text" />
+      </div>
+      <div>
+        <label for="">Password</label>
+        <input v-model="password" type="password" class="input-text" />
+      </div>
+      <div>
+        <span>{{ messageRequest }}</span>
+      </div>
+      <div>
+        <button type="button" class="login-button" @click="login">
+          Entrar
+        </button>
+      </div>
+    </form>
+  </div>
+</template>
+
+<script>
+export default {
+  components: {},
+  data() {
+    return {
+      username: '',
+      password: '',
+      messageRequest: ''
+    }
+  },
+  methods: {
+    login() {
+      const data = {
+        identifier: this.username,
+        password: this.password
+      }
+      this.messageRequest = 'Espera...'
+      this.$axios
+        .post('auth/local', data)
+        .then((res) => {
+          this.messageRequest = 'Datos correctos'
+          this.$axios.setToken(res.data.jwt, 'Bearer')
+          this.$router.push('/')
+        })
+        .catch(() => (this.messageRequest = 'Ocurrió un error'))
+    }
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.login-button {
+  @apply border p-4 mb-16 bg-blue-500;
+}
+</style>

--- a/plugins/axios.js
+++ b/plugins/axios.js
@@ -7,5 +7,4 @@
 
 export default function({ $axios }) {
   $axios.setBaseURL(process.env.BASE_URL_API)
-  $axios.setToken(process.env.TOKEN_HOSTEL_MANAGER, 'Bearer')
 }


### PR DESCRIPTION
# Descripción
- Formulario para realizar inicio de sesión y dejar de utilizar una variable de entorno para almacenar el token de autentificación
- Ruta para autentificación; `/login`
- El token no es persistente
- Se puede acceder a la ruta `/personas/registro` e intentar enviar datos, pero el resultado será error ya que el token tiene valor de `null`
- En la ruta principal `/` se mostrará el boton de `Entrar` si es que no hay token en los `headers` de `axios`, si existe token entonces se mostrará un enlace para entrar a la administración de personas que contiene el botón hacia el formulario de registro

# Capturas

- Login form

![Login form](https://user-images.githubusercontent.com/13499566/83717853-f9ce4380-a5f0-11ea-8d20-ba11c721841b.png)


